### PR TITLE
feat: Add friendly error display, test suite, and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run tests
+        run: node --test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to mermaid-tw5
+
+Thank you for your interest in improving the mermaid-tw5 plugin!
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork
+3. Run tests to make sure everything is working:
+   ```bash
+   node --test
+   ```
+
+## Coding Standards
+
+- **Indentation:** 4 spaces (no tabs)
+- **Quotes:** Single quotes for strings (double quotes are used in some older files — new code should use single)
+- **Semicolons:** Use them consistently
+- **Variable declarations:** `var` for compatibility with older TW5 environments
+- **No debug logging:** Do not leave `console.log` statements in production code
+- **Strict mode:** All modules begin with `'use strict';`
+
+## Pull Request Process
+
+1. Create a branch from `main` with a descriptive name:
+   - `feature/description` for new capabilities
+   - `fix/description` for bug fixes
+2. Make your changes
+3. Run tests locally: `node --test`
+4. Ensure your code follows the coding standards above
+5. Open a pull request to `main` with a clear description of what changed and why
+
+## Reporting Issues
+
+When reporting bugs, please include:
+
+- TiddlyWiki version
+- Browser and version (if applicable)
+- Steps to reproduce
+- Sample Mermaid syntax that triggers the issue
+- Any error messages (text or screenshot)

--- a/mermaid-tw5/plugins/mermaid-tw5/$__plugins_mermaid-tw5_wrapper.js
+++ b/mermaid-tw5/plugins/mermaid-tw5/$__plugins_mermaid-tw5_wrapper.js
@@ -21,14 +21,16 @@ modified: E Furlan 2022-05-08
         // by fkmiec 2023-05-21
         var d3 = require("$:/plugins/orange/mermaid-tw5/d3.v6.min.js");
 
-    // Changes to run on TiddlyWiki for Node.js - 2022-12-28
-    // if($tw.browser && !window.mermaidAPI) {
-    //     window.rocklib = new Rocklib();
-    //     window.mermaidAPI = require("$:/plugins/orange/mermaid-tw5/mermaid.min.js")
-    //         .mermaidAPI;
-    // }
+    function escapeHtml(text) {
+        if (text === null || text === undefined) { return ''; }
+        return String(text)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
 
-    let MermaidWidget = function(parseTreeNode, options) {
+    var MermaidWidget = function(parseTreeNode, options) {
         this.initialise(parseTreeNode, options);
     };
     MermaidWidget.prototype = new Widget();
@@ -46,13 +48,15 @@ modified: E Furlan 2022-05-08
                 // Add bind functions to support click events
                 // by fkmiec 2023-05-21
                 if (bindFunctions) {
-                    console.log("calling bindFunctions");
-                    bindFunctions(divNode);
-                    console.log("done calling bindFunctions");
+                    try {
+                        bindFunctions(divNode);
+                    } catch (bfErr) {
+                        console.error('[mermaid-tw5] bindFunctions error:', bfErr);
+                    }
                 }
             };
         try {
-            let options = {
+            var options = {
                 theme: ""
             };
             rocklib.getOptions(this, tag, options);
@@ -66,34 +70,41 @@ modified: E Furlan 2022-05-08
             });
             // START ZOOM LOGIC: Enable zooming the mermaid diagram with D3
             // by fkmiec 2023-05-21
-            let zoomEventListenersApplied = false;
-            let isZoomEnabled = false;
+            var zoomEventListenersApplied = false;
+            var isZoomEnabled = false;
 
             divNode.addEventListener('click', function() {
-                console.log("Zoom enabled: " + isZoomEnabled);
-                if(!zoomEventListenersApplied) {
-                    console.log("Executing svg.each...");
+                if (!zoomEventListenersApplied) {
                     var id = Date.now().toString(36);
-                    console.log("id=" + id);
-                    this.firstChild.setAttribute("id",id);
+                    this.firstChild.setAttribute("id", id);
                     var svg = d3.select("#" + id);
                     svg.html("<g>" + svg.html() + "</g>");
                     var inner = svg.select("g");
-                    var zoom = d3.zoom().filter(() => isZoomEnabled).on("zoom", function(event) {
+                    var zoom = d3.zoom().filter(function() { return isZoomEnabled; }).on("zoom", function(event) {
                         inner.attr("transform", event.transform);
                     });
                     svg.call(zoom);
                     zoomEventListenersApplied = true;
                 }
-                isZoomEnabled?isZoomEnabled=false:isZoomEnabled=true;
+                isZoomEnabled = !isZoomEnabled;
             });
             //END ZOOM LOGIC
 
             mermaidAPI.render(divNode.id, scriptBody, _insertSVG);
-            // window.mermaidAPI.render(divNode.id, scriptBody, _insertSVG);
 
         } catch (ex) {
-            divNode.innerText = ex;
+            divNode.innerHTML =
+                '<div style="border-left:3px solid #ff4444;background:#fff0f0;padding:8px 12px;">' +
+                '<p><strong>Mermaid diagram could not be rendered.</strong> The diagram syntax may contain an error.</p>' +
+                '<pre style="margin:8px 0;padding:6px;background:#ffffff;border:1px solid #ffcccc;overflow:auto;">' +
+                escapeHtml(scriptBody) +
+                '</pre>' +
+                '<details>' +
+                '<summary style="cursor:pointer;color:#666;font-size:12px;">Technical details</summary>' +
+                '<p style="margin:4px 0;font-size:12px;"><strong>' + escapeHtml(ex.name || 'Error') + ':</strong> ' +
+                escapeHtml(ex.message || String(ex)) + '</p>' +
+                '</details>' +
+                '</div>';
         }
         parent.insertBefore(divNode, nextSibling);
         this.domNodes.push(divNode);

--- a/tests/helpers/dom-mock.js
+++ b/tests/helpers/dom-mock.js
@@ -1,0 +1,52 @@
+'use strict';
+
+function MockElement(tagName) {
+    this.tagName = tagName;
+    this.attributes = {};
+    this.children = [];
+    this.style = {};
+    this.innerHTML = '';
+    this.innerText = '';
+    this._listeners = {};
+}
+
+MockElement.prototype.setAttribute = function(name, value) {
+    this.attributes[name] = String(value);
+};
+
+MockElement.prototype.getAttribute = function(name) {
+    return this.attributes[name] || null;
+};
+
+MockElement.prototype.addEventListener = function(event, handler) {
+    if (!this._listeners[event]) {
+        this._listeners[event] = [];
+    }
+    this._listeners[event].push(handler);
+};
+
+MockElement.prototype.removeEventListener = function(event, handler) {
+    if (this._listeners[event]) {
+        var idx = this._listeners[event].indexOf(handler);
+        if (idx !== -1) {
+            this._listeners[event].splice(idx, 1);
+        }
+    }
+};
+
+MockElement.prototype.insertBefore = function(newNode) {
+    this.children.push(newNode);
+};
+
+function MockDocument() {}
+
+MockDocument.prototype.createElement = function(tagName) {
+    return new MockElement(tagName);
+};
+
+global.document = new MockDocument();
+
+module.exports = {
+    MockElement: MockElement,
+    MockDocument: MockDocument
+};

--- a/tests/helpers/tw-bootstrap.js
+++ b/tests/helpers/tw-bootstrap.js
@@ -1,0 +1,171 @@
+'use strict';
+
+var fs = require('fs');
+var vm = require('vm');
+
+// ---------------------------------------------------------------------------
+// Global $tw mock
+// ---------------------------------------------------------------------------
+
+global.$tw = {
+    wiki: {
+        getTiddler: function() { return null; },
+        tiddlerExists: function() { return false; },
+        getTiddlerData: function() { return {}; }
+    },
+    modules: {
+        execute: function() { return {}; }
+    },
+    utils: {
+        parseStringArray: function() { return []; }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Widget base class mock
+// ---------------------------------------------------------------------------
+
+function MockWidget(parseTreeNode, options) {
+    this.initialise(parseTreeNode, options);
+}
+
+MockWidget.prototype.initialise = function(parseTreeNode, options) {
+    this.parseTreeNode = parseTreeNode || {};
+    this.attributes = (options && options.attributes) ? options.attributes : {};
+    this.children = [];
+    this.domNodes = [];
+    this.document = global.document;
+    this.wiki = global.$tw.wiki;
+    this.parentWidget = null;
+    this.variables = {};
+};
+
+MockWidget.prototype.computeAttributes = function() {};
+MockWidget.prototype.execute = function() {};
+MockWidget.prototype.refresh = function() { return false; };
+
+MockWidget.prototype.getAttribute = function(name, defaultValue) {
+    return this.attributes[name] !== undefined ? this.attributes[name] : defaultValue;
+};
+
+MockWidget.prototype.getVariable = function(name) {
+    return this.variables[name] || null;
+};
+
+MockWidget.prototype.setVariable = function(name, value) {
+    this.variables[name] = value;
+};
+
+// ---------------------------------------------------------------------------
+// Mermaid API mock — Mermaid 9 callback style: render(id, src, callback)
+// ---------------------------------------------------------------------------
+
+var mockMermaidAPI = {
+    initialize: function() {},
+    render: function(id, source, callback) {
+        if (source && source.indexOf('INVALID_SYNTAX') !== -1) {
+            var err = new Error('Syntax error in graph');
+            err.name = 'MermaidParseError';
+            throw err;
+        }
+        var svg = '<svg id="' + id + '"><rect width="100" height="50"/></svg>';
+        if (callback) {
+            callback(svg, null);
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// D3 mock
+// ---------------------------------------------------------------------------
+
+var mockD3 = {
+    select: function() {
+        return {
+            html: function() { return this; },
+            select: function() { return this; },
+            attr: function() { return this; },
+            call: function() { return this; }
+        };
+    },
+    zoom: function() {
+        return {
+            filter: function() { return this; },
+            on: function() { return this; }
+        };
+    }
+};
+
+// ---------------------------------------------------------------------------
+// TW-style module loader
+// ---------------------------------------------------------------------------
+
+var moduleCache = {};
+
+var pathMap = {
+    '$:/plugins/orange/mermaid-tw5/widget-tools.js':  'mermaid-tw5/plugins/mermaid-tw5/$__plugins_mermaid-tw5_widget-tools.js',
+    '$:/plugins/orange/mermaid-tw5/typed-parser.js':  'mermaid-tw5/plugins/mermaid-tw5/$__plugins_mermaid-tw5_typed-parser.js',
+    '$:/plugins/orange/mermaid-tw5/wrapper.js':        'mermaid-tw5/plugins/mermaid-tw5/$__plugins_mermaid-tw5_wrapper.js'
+};
+
+function twRequire(moduleName) {
+    if (moduleCache[moduleName]) {
+        return moduleCache[moduleName];
+    }
+
+    if (moduleName === '$:/core/modules/widgets/widget.js') {
+        return { widget: MockWidget };
+    }
+    if (moduleName === '$:/plugins/orange/mermaid-tw5/mermaid.min.js') {
+        return { mermaidAPI: mockMermaidAPI };
+    }
+    if (moduleName === '$:/plugins/orange/mermaid-tw5/d3.v6.min.js') {
+        return mockD3;
+    }
+
+    var localPath = pathMap[moduleName];
+    if (!localPath) {
+        return require(moduleName);
+    }
+
+    var exports = {};
+    var code = fs.readFileSync(localPath, 'utf8');
+
+    var context = vm.createContext({
+        exports: exports,
+        require: twRequire,
+        $tw: global.$tw,
+        document: global.document,
+        console: console,
+        Array: Array, Object: Object, String: String, Number: Number,
+        Boolean: Boolean, Date: Date, Math: Math, JSON: JSON,
+        Error: Error, RegExp: RegExp,
+        parseInt: parseInt, parseFloat: parseFloat,
+        isNaN: isNaN, isFinite: isFinite,
+        undefined: undefined, Infinity: Infinity, NaN: NaN
+    });
+
+    vm.runInContext(code, context);
+    moduleCache[moduleName] = exports;
+    return exports;
+}
+
+function loadModule(moduleName) {
+    return twRequire(moduleName);
+}
+
+function clearModuleCache(moduleName) {
+    if (moduleName) {
+        delete moduleCache[moduleName];
+    } else {
+        Object.keys(moduleCache).forEach(function(k) { delete moduleCache[k]; });
+    }
+}
+
+module.exports = {
+    loadModule: loadModule,
+    twRequire: twRequire,
+    MockWidget: MockWidget,
+    mockMermaidAPI: mockMermaidAPI,
+    clearModuleCache: clearModuleCache
+};

--- a/tests/wrapper.test.js
+++ b/tests/wrapper.test.js
@@ -1,0 +1,70 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { loadModule, clearModuleCache } from './helpers/tw-bootstrap.js';
+import './helpers/dom-mock.js';
+
+describe('wrapper', () => {
+    beforeEach(function() {
+        clearModuleCache('$:/plugins/orange/mermaid-tw5/wrapper.js');
+    });
+
+    it('exports MermaidWidget constructor', () => {
+        var exports = loadModule('$:/plugins/orange/mermaid-tw5/wrapper.js');
+        assert.ok(exports.mermaid, 'should export mermaid widget constructor');
+    });
+
+    it('instantiates without errors', () => {
+        var MermaidWidget = loadModule('$:/plugins/orange/mermaid-tw5/wrapper.js').mermaid;
+        var widget = new MermaidWidget({ text: 'graph TD; A-->B' }, {});
+        assert.ok(widget, 'should create widget instance');
+    });
+
+    it('render produces a DOM element containing SVG for a valid diagram', () => {
+        var MermaidWidget = loadModule('$:/plugins/orange/mermaid-tw5/wrapper.js').mermaid;
+        var widget = new MermaidWidget({ text: 'graph TD; A-->B' }, {});
+        widget.document = global.document;
+        widget.attributes = {};
+        widget.wiki = global.$tw.wiki;
+        widget.variables = {};
+
+        var parent = global.document.createElement('div');
+        widget.render(parent, null);
+
+        assert.strictEqual(widget.domNodes.length, 1, 'should push one DOM node');
+        var node = widget.domNodes[0];
+        assert.ok(node, 'should have a DOM node');
+        assert.ok(node.innerHTML.indexOf('<svg') !== -1, 'innerHTML should contain an SVG element');
+    });
+
+    it('handles invalid diagram syntax without throwing', () => {
+        var MermaidWidget = loadModule('$:/plugins/orange/mermaid-tw5/wrapper.js').mermaid;
+        var widget = new MermaidWidget({ text: 'INVALID_SYNTAX' }, {});
+        widget.document = global.document;
+        widget.attributes = {};
+        widget.wiki = global.$tw.wiki;
+        widget.variables = {};
+
+        var parent = global.document.createElement('div');
+        assert.doesNotThrow(function() {
+            widget.render(parent, null);
+        }, 'render should not throw for invalid syntax');
+
+        assert.strictEqual(widget.domNodes.length, 1, 'should still push one DOM node');
+    });
+
+    it('displays a friendly error message for invalid syntax', () => {
+        var MermaidWidget = loadModule('$:/plugins/orange/mermaid-tw5/wrapper.js').mermaid;
+        var widget = new MermaidWidget({ text: 'INVALID_SYNTAX' }, {});
+        widget.document = global.document;
+        widget.attributes = {};
+        widget.wiki = global.$tw.wiki;
+        widget.variables = {};
+
+        var parent = global.document.createElement('div');
+        widget.render(parent, null);
+
+        var node = widget.domNodes[0];
+        assert.ok(node.innerHTML.indexOf('could not be rendered') !== -1, 'error message should explain the failure');
+        assert.ok(node.innerHTML.indexOf('INVALID_SYNTAX') !== -1, 'error message should include the diagram source');
+    });
+});


### PR DESCRIPTION
Hi! 
I hope this finds you well. I've been using and enjoying mermaid-tw6. Thank you for maintaining it!. I made a few improvements in my fork that I think could benefit the upstream project, and I'd love to contribute them back if   
  you're interested.                                                                                                                                                                                                                          
                                                                                                                                                                                                                                              
  This PR contains three independent but related improvements:
                                               
  1. Friendlier error display in wrapper.js

  Before: a rendering failure set divNode.innerText = ex, which showed a raw JavaScript Error object as plain text.                                                                                                                           
   
  After: a formatted error panel showing a clear heading, the full diagram source (so the user can see what failed), and the error name/message in a collapsible <details> block. Also removed three console.log debug statements left in the 
  bindFunctions callback and the D3 zoom handler.
                                                                                                                                                                                                                                              
  2. Test suite                          
                                               
  A lightweight test suite using Node.js's built-in node:test runner — no npm install required. Uses a small TW5 module-loader mock so tests run without a browser or TiddlyWiki installation (node --test). Covers widget construction,      
  successful render, graceful handling of invalid syntax, and the error message content.
                                                                                                                                                                                                                                              
  3. GitHub Actions CI                   
                                               
  A minimal .github/workflows/test.yml that runs the test suite on every push and pull request to main.

  ---
  All 5 tests pass. Happy to adjust anything — coding style, commit structure, scope — whatever works best for you. And of course, no pressure at all if this doesn't fit your plans for the project. Thank you for your time!

-----------
- wrapper.js: replace bare `divNode.innerText = ex` with a formatted error panel showing the diagram source and the error message, making broken diagrams much easier to diagnose; add escapeHtml() helper to prevent raw HTML in error output
- wrapper.js: remove console.log debug statements left in bindFunctions and the D3 zoom handler
- tests/: add Node.js test suite (5 tests) covering widget construction, rendering to SVG, and graceful error display for invalid syntax; uses a lightweight TW5 module-loader mock so no browser or TiddlyWiki install is required to run tests
- .github/workflows/test.yml: run `node --test` on every push and PR
- CONTRIBUTING.md: document coding standards and the PR process